### PR TITLE
Clear extension

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -32,6 +32,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
+    private boolean previouslyClear;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -40,11 +41,26 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
+        this.previouslyClear = false;
     }
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        if (this.previouslyClear) {
+            this.previouslyClear = false;
+            if (commandText.equalsIgnoreCase("y")) {
+                model.setConfirmClear(true);
+                // execute clear command, clear successful
+            }
+            // execute clear command, clear cancelled
+            commandText = "clear";
+        }
+
+        if (commandText.equalsIgnoreCase("clear")) {
+            this.previouslyClear = true;
+        }
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -48,6 +48,8 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
+        String originalCommandText = commandText;
+
         if (this.previouslyClear) {
             this.previouslyClear = false;
             if (commandText.equalsIgnoreCase("y")) {
@@ -58,7 +60,7 @@ public class LogicManager implements Logic {
             commandText = "clear";
         }
 
-        if (commandText.equalsIgnoreCase("clear")) {
+        if (originalCommandText.equalsIgnoreCase("clear")) {
             this.previouslyClear = true;
         }
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -48,11 +49,8 @@ public class LogicManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
-        String originalCommandText = commandText;
-
         if (this.previouslyClear) {
-            this.previouslyClear = false;
-            if (commandText.equalsIgnoreCase("y")) {
+            if (commandText.trim().equalsIgnoreCase("y")) {
                 model.setConfirmClear(true);
                 // execute clear command, clear successful
             }
@@ -60,13 +58,16 @@ public class LogicManager implements Logic {
             commandText = "clear";
         }
 
-        if (originalCommandText.equalsIgnoreCase("clear")) {
-            this.previouslyClear = true;
-        }
-
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
+
+        // check if command was clear and model is awaiting confirmation
+        if (command instanceof ClearCommand && model.isAwaitingClear()) {
+            this.previouslyClear = true;
+        } else {
+            this.previouslyClear = false;
+        }
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,13 +11,36 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_CONFIRMATION = "Are you sure you want to clear ALL contacts? [y/n]";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_CANCELLED = "Clear cancelled!";
+
+    private static boolean awaitingConfirmation = false;
 
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        if (!model.isAwaitingClear()) {
+            model.setAwaitingClear(true);
+            return new CommandResult(MESSAGE_CONFIRMATION);
+        } else {
+            model.setAwaitingClear(false); // Reset the confirmation state
+            if (model.isConfirmClear()) {
+                model.setConfirmClear(false);
+                model.setAddressBook(new AddressBook());
+                return new CommandResult(MESSAGE_SUCCESS);
+            } else {
+                return new CommandResult(MESSAGE_CANCELLED);
+            }
+        }
+    }
+
+    public static boolean isAwaitingConfirmation() {
+        return awaitingConfirmation;
+    }
+
+    public static void setAwaitingConfirmation(boolean awaitingConfirmation) {
+        ClearCommand.awaitingConfirmation = awaitingConfirmation;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -15,9 +15,6 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_CANCELLED = "Clear cancelled!";
 
-    private static boolean awaitingConfirmation = false;
-
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -35,12 +35,4 @@ public class ClearCommand extends Command {
             }
         }
     }
-
-    public static boolean isAwaitingConfirmation() {
-        return awaitingConfirmation;
-    }
-
-    public static void setAwaitingConfirmation(boolean awaitingConfirmation) {
-        ClearCommand.awaitingConfirmation = awaitingConfirmation;
-    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -84,4 +84,38 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns true if the clear command was the previously called command.
+     * This should be used to check whether the user has the raised the intention to clear all data from
+     * the address book.
+     *
+     * @return true if the clear operation was previously called, false otherwise.
+     */
+    boolean isAwaitingClear();
+
+    /**
+     * Sets the waiting status for clearing the address book.
+     * This should be called to when user inputs "clear".
+     *
+     * @param isAwaitingClear true to indicate a "clear" command has been called, false otherwise.
+     */
+    void setAwaitingClear(boolean isAwaitingClear);
+
+    /**
+     * Returns true if the clear operation has been confirmed.
+     * This should be used to check whether the user has confirmed the intention to clear all data from the
+     * address book.
+     *
+     * @return true if the clear operation is confirmed, false otherwise.
+     */
+    boolean isConfirmClear();
+
+    /**
+     * Sets the confirmation status for clearing the address book.
+     * This should be called to confirm or cancel the clear operation based on user input.
+     *
+     * @param isConfirmClear true to set the clear operation as confirmed, false otherwise.
+     */
+    void setConfirmClear(boolean isConfirmClear);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,8 +24,9 @@ public class ModelManager implements Model {
     private final FilteredList<Person> filteredPersons;
 
     /** Fields to track clear confirmation */
-    private boolean isConfirmClear;
     private boolean isAwaitingClear;
+    private boolean isConfirmClear;
+
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,10 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    /** Fields to track clear confirmation */
+    private boolean isConfirmClear;
+    private boolean isAwaitingClear;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -34,6 +38,8 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        this.isConfirmClear = false;
+        this.isAwaitingClear = false;
     }
 
     public ModelManager() {
@@ -145,4 +151,25 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(otherModelManager.filteredPersons);
     }
 
+    //=========== Command State Management =============================================================
+
+    @Override
+    public boolean isAwaitingClear() {
+        return this.isAwaitingClear;
+    }
+
+    @Override
+    public void setAwaitingClear(boolean isAwaitingClear) {
+        this.isAwaitingClear = isAwaitingClear;
+    }
+
+    @Override
+    public boolean isConfirmClear() {
+        return this.isConfirmClear;
+    }
+
+    @Override
+    public void setConfirmClear(boolean isConfirmClear) {
+        this.isConfirmClear = isConfirmClear;
+    }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -51,6 +52,36 @@ public class LogicManagerTest {
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);
     }
+
+    @Test
+    public void execute_logicManagerRequestsClearConfirmation_promptsConfirmation() throws Exception {
+        String clearCommand = "clear";
+        CommandResult result = logic.execute(clearCommand);
+        assertEquals(ClearCommand.MESSAGE_CONFIRMATION, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_logicManagerProcessesClearConfirmation_clearsAddressBook() throws Exception {
+        model.setAwaitingClear(true);
+        model.setConfirmClear(true);
+
+        String clearCommand = "clear";
+        CommandResult result = logic.execute(clearCommand);
+        assertEquals(ClearCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_logicManagerHandlesClearCancellation_cancellationAcknowledged() throws Exception {
+        model.setAwaitingClear(true);
+        model.setConfirmClear(false);
+
+        String clearCommand = "clear";
+        CommandResult result = logic.execute(clearCommand);
+        assertEquals(ClearCommand.MESSAGE_CANCELLED, result.getFeedbackToUser());
+    }
+
+
+
 
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -77,6 +79,29 @@ public class LogicManagerTest {
 
         String clearCommand = "clear";
         CommandResult result = logic.execute(clearCommand);
+        assertEquals(ClearCommand.MESSAGE_CANCELLED, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_clearFollowedByNo_cancelsClear() throws CommandException, ParseException {
+        String clearCommand = "clear";
+        logic.execute(clearCommand);
+        assertTrue(model.isAwaitingClear());
+        assertFalse(model.isConfirmClear());
+    }
+
+    @Test
+    public void execute_clearConfirmedByUser_clearsAddressBook() throws CommandException, ParseException {
+        logic.execute("clear");
+        CommandResult result = logic.execute("y");
+        assertEquals(ClearCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+        assertTrue(model.getAddressBook().getPersonList().isEmpty());
+    }
+
+    @Test
+    public void execute_clearCancelledByUser_doesNotClearAddressBook() throws CommandException, ParseException {
+        logic.execute("clear");
+        CommandResult result = logic.execute("n");
         assertEquals(ClearCommand.MESSAGE_CANCELLED, result.getFeedbackToUser());
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -63,6 +63,14 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_twoConsecutiveClears_clearCancelled() throws Exception {
+        String clearCommand = "clear";
+        CommandResult result = logic.execute(clearCommand);
+        CommandResult nextResult = logic.execute(clearCommand);
+        assertEquals(ClearCommand.MESSAGE_CANCELLED, nextResult.getFeedbackToUser());
+    }
+
+    @Test
     public void execute_logicManagerProcessesClearConfirmation_clearsAddressBook() throws Exception {
         model.setAwaitingClear(true);
         model.setConfirmClear(true);
@@ -95,7 +103,6 @@ public class LogicManagerTest {
         logic.execute("clear");
         CommandResult result = logic.execute("y");
         assertEquals(ClearCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
-        assertTrue(model.getAddressBook().getPersonList().isEmpty());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -80,9 +80,6 @@ public class LogicManagerTest {
         assertEquals(ClearCommand.MESSAGE_CANCELLED, result.getFeedbackToUser());
     }
 
-
-
-
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -157,6 +157,26 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean isAwaitingClear() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAwaitingClear(boolean isAwaitingClear) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean isConfirmClear() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setConfirmClear(boolean isConfirmClear) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -13,20 +13,60 @@ import seedu.address.model.UserPrefs;
 public class ClearCommandTest {
 
     @Test
-    public void execute_emptyAddressBook_success() {
+    public void execute_emptyAddressBook_confirmation() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CONFIRMATION, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyAddressBook_success() {
+        Model model = new ModelManager();
+        model.setAwaitingClear(true);
+        model.setConfirmClear(true);
+        Model expectedModel = new ModelManager();
+        expectedModel.setAddressBook(new AddressBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
+    public void execute_emptyAddressBook_cancelled() {
+        Model model = new ModelManager();
+        model.setAwaitingClear(true);
+        model.setConfirmClear(false);
+        Model expectedModel = new ModelManager();
+
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CANCELLED, expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyAddressBook_confirmation() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CONFIRMATION, expectedModel);
+    }
+
+    @Test
     public void execute_nonEmptyAddressBook_success() {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.setAwaitingClear(true);
+        model.setConfirmClear(true);
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
+    @Test
+    public void execute_nonEmptyAddressBook_cancelled() {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.setAwaitingClear(true);
+        model.setConfirmClear(false);
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_CANCELLED, expectedModel);
+    }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -94,6 +94,43 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void isAwaitingClear_initialState_false() {
+        assertFalse(modelManager.isAwaitingClear());
+    }
+
+    @Test
+    public void setAwaitingClear_true_stateChanged() {
+        modelManager.setAwaitingClear(true);
+        assertTrue(modelManager.isAwaitingClear());
+    }
+
+    @Test
+    public void setAwaitingClear_false_stateChanged() {
+        modelManager.setAwaitingClear(true); // Set to true first
+        modelManager.setAwaitingClear(false); // Then set to false
+        assertFalse(modelManager.isAwaitingClear());
+    }
+
+    @Test
+    public void isConfirmClear_initialState_false() {
+        assertFalse(modelManager.isConfirmClear());
+    }
+
+    @Test
+    public void setConfirmClear_true_stateChanged() {
+        modelManager.setConfirmClear(true);
+        assertTrue(modelManager.isConfirmClear());
+    }
+
+    @Test
+    public void setConfirmClear_false_stateChanged() {
+        ModelManager modelManager = new ModelManager();
+        modelManager.setConfirmClear(true); // Set to true first
+        modelManager.setConfirmClear(false); // Then set to false
+        assertFalse(modelManager.isConfirmClear());
+    }
+
+    @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();


### PR DESCRIPTION
Main idea is to modify attributes in the model object that is passed from the LogicManager class to the ClearCommand class. The attributes, isAwaitingClear and isConfirmClear inside the ModelManager class, act as flags that will tell the ClearCommand class whether to perform the clear or not.

Majority of code logic is inside updated ClearCommand class as well as the LogicManager class. Mostly had to do with keeping track of the previous command to see if it was "clear", and specially handling the following user input that comes after that inside the LogicManager class.